### PR TITLE
Check if XDG_RUNTIME_DIR path actually exists.

### DIFF
--- a/bin/cenv
+++ b/bin/cenv
@@ -367,7 +367,7 @@ else
             EXTRA_OPTS="${EXTRA_OPTS} -B /etc/OpenCL/vendors"
         fi
 
-        if [[ "$XDG_RUNTIME_DIR" == /run/* ]] ; then
+        if [[ "$XDG_RUNTIME_DIR" == /run/* ]] && [[ -d "$XDG_RUNTIME_DIR" ]]; then
             EXTRA_OPTS="${EXTRA_OPTS} -B $XDG_RUNTIME_DIR"
         fi
 


### PR DESCRIPTION
Fixes issue #15.

XDG_RUNTIME_DIR might not actually exist, even though it's set.

This check should make sure that it is a directory, so it can be mounted.