### PR TITLE
Mount /user/.vscode_server to $HOME/.vscode_server

### DIFF
--- a/README-VSCode.md
+++ b/README-VSCode.md
@@ -44,7 +44,9 @@ In your VS-Code settings *on your local system*, set
 "remote.SSH.enableRemoteCommand": true
 ```
 
-### Step 4
+### Step 4 (Shifter-only)
+
+This step is optional if you use Apptainer, it is only required with Shifter as the container runtime.
 
 Since VS-Code reuses remote server instances, the above is not sufficient to run multiple container images on the same
 remote host at the same time. To get *separate* (per container image) VS-Code server instances on the *same host*, add
@@ -58,6 +60,8 @@ something like this to your VS-Code settings *on your local system*:
   "othercenv~otherhost": "~/.vscode-container/othercenv"
 }
 ```
+
+When using Apptainer, cenv will automatically try to bind-mount `/user/.vscode-server` to `$HOME/.vscode-server`, so setting `remote.SSH.serverInstallPath` in VS-Code is not required.
 
 
 ### Step 5

--- a/bin/cenv
+++ b/bin/cenv
@@ -12,6 +12,7 @@ fi
 export CENV_BASE_DIR="${CENV_BASE_DIR:-${VENV_BASE_DIR:-${default_basedir}}}"
 export CENV_USER_MNT="${CENV_USER_MNT:-${VENV_USER_MNT:-/user}}"
 export CENV_HOME_MNT="${CENV_HOME_MNT:-${VENV_HOME_MNT:-/homedir}}"
+export CENV_VSCS_MNT="${CENV_VSCS_MNT:-${VENV_HOME_MNT:-${HOME}/.vscode-server}}"
 
 if [ "${CENV_BASE_DIR}" = "${legacy_default_basedir}" ]; then
     echo "WARNING: Defaulting to legacy CENV_BASE_DIR=\"\${HOME}/.venv\", please rename \"\${HOME}/.venv\" to \"\${HOME}/.cenv\". Support for \"\${HOME}/.venv\" will be removed in the future!" >&2
@@ -140,6 +141,10 @@ ENVIRONMENT VARIABLES
                     still (depeding on Singularity configuration) be available
                     under it's original path as well.
 
+* CENV_VSCS_MNT     Site-independent mount point in container instance for
+                    "\${CENV_USER_MNT}/.vscode-server". Defaults to
+                    "\${HOME}/.vscode-server".
+
 * CENV_RUNTIME      cenv container runtime engine, either "apptainer",
                     "singularity" or "shifter" or "auto" (the default).
 
@@ -244,14 +249,10 @@ cenv_create() {
         else
             echo "INFO: Command \"symlinks\" not available, using absolute symlink for \"${IMG_LINK_PATH}\"." >&2
         fi
-
-        mkdir -p "${CENV_DIR}/user"
     elif [ "${CENV_RUNTIME}" = "shifter" ] ; then
         mkdir -p "${CENV_DIR}"
         IMG_LINKFILE="${CENV_DIR}/rootfs.shifter"
         echo "${CENV_IMG}" > "${IMG_LINKFILE}"
-
-        # mkdir -p "${CENV_DIR}/user"
     else
         echo "ERROR: cenv internal error." >&2; exit 1
     fi
@@ -341,6 +342,7 @@ else
 
         CENV_USER_DIR="${CENV_DIR}/user"
         mkdir -p "${CENV_USER_DIR}"
+        mkdir -p "${CENV_USER_DIR}/.vscode-server"
 
         if [ "${CENV_USER_MNT}" == "none" ] ; then
             CENV_USER_MNT="${CENV_USER_DIR}"
@@ -403,6 +405,7 @@ else
             exec "${CENV_RUNTIME}" "${CMD}" ${EXTRA_OPTS} \
                 -B "${CENV_USER_DIR}:${CENV_USER_MNT}" \
                 -B "${HOME}:${CENV_HOME_MNT}" \
+                -B "${CENV_USER_DIR}/.vscode-server:${CENV_VSCS_MNT}" \
                 "${FS_IMG}" "$@"
         else
             exec "${CENV_RUNTIME}" "${CMD}" ${EXTRA_OPTS} \
@@ -429,12 +432,13 @@ else
         fi
         CENV_USER_DIR="${parent_dir}/${subst_userdir}"
         mkdir -p "${CENV_USER_DIR}"
+        mkdir -p "${CENV_USER_DIR}/.vscode-server"
 
         export PS1="[\u@\[\e[1m\]${CENV_NAME}\[\e[m\] cenv] \w > "
 
         if [ "${CENV_USER_MNT}" != "${CENV_USER_DIR}" ] ; then
             exec shifter --image="${img_name}" \
-                --volume="${CENV_USER_DIR}:${CENV_USER_MNT};${HOME}:${CENV_HOME_MNT}" \
+                --volume="${CENV_USER_DIR}:${CENV_USER_MNT};${HOME}:${CENV_HOME_MNT};${CENV_USER_DIR}/.vscode-server:${CENV_VSCS_MNT}" \
                  ${EXTRA_OPTS} -- "$@"
         else
             exec shifter --image="${img_name}" \

--- a/bin/cenv
+++ b/bin/cenv
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+find_this_cenv_command() {
+    (echo "${0}" | grep -q '^/') && echo "${0}" || (cd "`pwd`/`dirname \"${0}\"`" && echo "`pwd`/`basename ${0}`")
+}
+export CENV_BIN=`find_this_cenv_command`
+
 test -f "${HOME}/.cenvrc" && source "${HOME}/.cenvrc"
 
 legacy_default_basedir="${HOME}/.venv"
@@ -148,10 +153,18 @@ ENVIRONMENT VARIABLES
 * CENV_RUNTIME      cenv container runtime engine, either "apptainer",
                     "singularity" or "shifter" or "auto" (the default).
 
-* CENV_APPTAINER_OPTS  Additional optins to pass when running "apptainer", e.g.
+* CENV_GPU          (Apptainer-only) Select GPU backend, currently may be
+                    "cuda", "rocm", "opencl" or "none". If not set, cenv will
+                    try to autodetect the appropriate backend.
+
+* CENV_APPTAINER_OPTS  Additional options to pass when running "apptainer", e.g.
                        "-B /some/dir:/some/dir".
 
 * CENV_SHIFTER_OPTS  Additional to pass when running "shifter".
+
+cenv sets the environment variable CENV_BIN to the absolute path to cenv
+itself. This can be useful in distributed scenarios, e.g. when generating
+batch job scripts that should not rely on cenv being on PATH.
 
 
 CONFIGURATION FILES

--- a/bin/venv
+++ b/bin/venv
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-thisdir() {
-	(echo "${0}" | grep -q '^/') && dirname "${0}" || (cd "`pwd`/`dirname \"${0}\"`" && pwd)
-}
-
-echo "WARNING: use cenv instead of venv, the venv command has been deprecated and will be removed in the future!" >&2
-
-`thisdir`/cenv "$@"


### PR DESCRIPTION
Ensures Visual Studio remote SSH servers run inside of cenv instances via RemoteCommand don't conflict with each other and non-cenv VS-code server instances.

Setting `remote.SSH.serverInstallPath` is no longer necessary.