### PR TITLE
add optional cenv-specific rc-file

### DIFF
--- a/bin/cenv
+++ b/bin/cenv
@@ -303,6 +303,7 @@ elif [ "${CENV_NAME_ARG}" = "--create" ] ; then
     cenv_create "$@"
 else
     CENV_DIR="${CENV_BASE_DIR}/${CENV_NAME_ARG}"
+    test -f "${CENV_DIR}/.cenvrc" && source "${CENV_DIR}/.cenvrc"
 
     export CENV_NAME="${CENV_NAME_ARG}"
     # Legacy support:

--- a/bin/cenv
+++ b/bin/cenv
@@ -174,6 +174,11 @@ CONFIGURATION FILES
   compatible) shell script before doing anything else. It's a convenient
   place to set environment variables like CENV_BASE_DIR,
   CENV_APPTAINER_OPTS, etc.
+
+* "\$CENV_BASE_DIR/\$CENV_NAME/.cenvrc" Create this file after
+  creating the container environment to set up environment-specific options. If
+  present, ${PROG_NAME} will "source" this (bash compatible) shell script
+  before invoking the container runtime.
 EOF
 } # swmod_list_usage()
 


### PR DESCRIPTION
Thanks for your awesome work! I've found it necessary to define specific apptainer arguments (`EXTRA_OPTS`) per environment in my use case.

This PR implements a simple addition: It looks for a `.cenvrc` file in the `CENV_DIR` and sources its contents if available.

I used this to specify certain mounts and think it might be useful in other cases as well. Feel free to merge the PR if you find this useful.