### PR TITLE
Add CENV_HOME_DIR and allow override, also add support for Rust

### DIFF
--- a/bin/cenv
+++ b/bin/cenv
@@ -134,9 +134,13 @@ ENVIRONMENT VARIABLES
 * CENV_BASE_DIR     Base path for virtual environment directories. Defaults
                     to "\${HOME}/.cenv".
 
-* CENV_USER_MNT     Site-independent mount point in container instance for
-                    "user"-directory (located inside virtual environment
-                    directory). Defaults to "/user".
+* CENV_USER_DIR     Host directory used as the "user"-directory for storing
+                    user-specific data. Defaults to
+                    "\${CENV_BASE_DIR}/\${CENV_NAME}/user"
+                     (located inside virtual environment directory).
+
+* CENV_USER_MNT     Site-independent mount point for "\${CENV_USER_DIR}" in
+                    container instance for "user"-directory. Defaults to "/user".
 
 * CENV_HOME_DIR     Host directory to use/mount as the home directory inside the
                     container. Defaults to "\${HOME}".
@@ -379,7 +383,7 @@ else
             exit 1
         fi
 
-        CENV_USER_DIR="${CENV_DIR}/user"
+        CENV_USER_DIR="${CENV_USER_DIR:-${CENV_DIR}/user}"
         mkdir -p "${CENV_USER_DIR}"
         mkdir -p "${CENV_USER_DIR}/.vscode-server"
 
@@ -512,7 +516,7 @@ else
         if [ ! -e "${CENV_DIR}/user" ] ; then
             ln -s "../../${subst_userdir}" "${CENV_DIR}/user"
         fi
-        CENV_USER_DIR="${parent_dir}/${subst_userdir}"
+        CENV_USER_DIR="${CENV_USER_DIR:-${parent_dir}/${subst_userdir}}"
         mkdir -p "${CENV_USER_DIR}"
         mkdir -p "${CENV_USER_DIR}/.vscode-server"
 

--- a/bin/cenv
+++ b/bin/cenv
@@ -476,7 +476,7 @@ else
 
         if [ "${CENV_RUNTIME}" = "apptainer" ]; then
             if [ "${CENV_HOME_DIR}" != "${HOME}" ]; then
-                export APPTAINER_HOME="${CENV_HOME_DIR}"
+                export APPTAINER_HOME="${CENV_HOME_MNT}"
             fi
             export APPTAINERENV_PS1="[\u@\[\e[1m\]${CENV_NAME}\[\e[m\] cenv] \w > "
             export APPTAINER_SHELL="${APPTAINER_SHELL:-${SHELL}}"

--- a/bin/cenv
+++ b/bin/cenv
@@ -361,6 +361,10 @@ else
     export JULIA_DEPOT_PATH="${CENV_USER_MNT}/.julia:"
     export JULIA_PKG_DEVDIR="${CENV_USER_MNT}/.julia/dev"
 
+    # Special exports for Rust:
+    export CARGO_HOME="${CENV_USER_MNT}/.cargo"
+    export RUSTUP_HOME="${CENV_USER_MNT}/.rustup"
+
     set_cenv_runtime
     if [ "${CENV_RUNTIME}" = "apptainer" ] ||
        [ "${CENV_RUNTIME}" = "singularity" ]; then
@@ -477,12 +481,12 @@ else
             export APPTAINERENV_PS1="[\u@\[\e[1m\]${CENV_NAME}\[\e[m\] cenv] \w > "
             export APPTAINER_SHELL="${APPTAINER_SHELL:-${SHELL}}"
             # Add user bin dir to path:
-            export APPTAINERENV_PREPEND_PATH="${CENV_USER_MNT}/.local/bin:${CENV_USER_MNT}/.julia/bin"
+            export APPTAINERENV_PREPEND_PATH="${CENV_USER_MNT}/.local/bin:${CENV_USER_MNT}/.julia/bin:${CENV_USER_MNT}/.cargo/bin"
         else
             export SINGULARITYENV_PS1="[\u@\[\e[1m\]${CENV_NAME}\[\e[m\] cenv] \w > "
             export SINGULARITY_SHELL="${SINGULARITY_SHELL:-${SHELL}}"
             # Add user bin dir to path:
-            export SINGULARITYENV_PREPEND_PATH="${CENV_USER_MNT}/.local/bin:${CENV_USER_MNT}/.julia/bin"
+            export SINGULARITYENV_PREPEND_PATH="${CENV_USER_MNT}/.local/bin:${CENV_USER_MNT}/.julia/bin:${CENV_USER_MNT}/.cargo/bin"
         fi
 
         export debian_chroot="${CENV_NAME}"

--- a/bin/cenv
+++ b/bin/cenv
@@ -15,9 +15,6 @@ if [ -e "${legacy_default_basedir}" -a ! -e "${default_basedir}" ]; then
 fi
 
 export CENV_BASE_DIR="${CENV_BASE_DIR:-${VENV_BASE_DIR:-${default_basedir}}}"
-export CENV_USER_MNT="${CENV_USER_MNT:-${VENV_USER_MNT:-/user}}"
-export CENV_HOME_MNT="${CENV_HOME_MNT:-${VENV_HOME_MNT:-/homedir}}"
-export CENV_VSCS_MNT="${CENV_VSCS_MNT:-${VENV_HOME_MNT:-${HOME}/.vscode-server}}"
 
 if [ "${CENV_BASE_DIR}" = "${legacy_default_basedir}" ]; then
     echo "WARNING: Defaulting to legacy CENV_BASE_DIR=\"\${HOME}/.venv\", please rename \"\${HOME}/.venv\" to \"\${HOME}/.cenv\". Support for \"\${HOME}/.venv\" will be removed in the future!" >&2
@@ -140,6 +137,9 @@ ENVIRONMENT VARIABLES
 * CENV_USER_MNT     Site-independent mount point in container instance for
                     "user"-directory (located inside virtual environment
                     directory). Defaults to "/user".
+
+* CENV_HOME_DIR     Host directory to use/mount as the home directory inside the
+                    container. Defaults to "\${HOME}".
 
 * CENV_HOME_MNT     Site-independent mount point in container instance for
                     "\${HOME}". Defaults to "/homedir". "${HOME}" itself will
@@ -321,6 +321,15 @@ else
         source "${CENV_DIR}/.cenvrc"
     fi
 
+    export CENV_USER_MNT="${CENV_USER_MNT:-${VENV_USER_MNT:-/user}}"
+    export CENV_HOME_DIR="${CENV_HOME_DIR:-${VENV_HOME_DIR:-${HOME}}}"
+    export CENV_HOME_MNT="${CENV_HOME_MNT:-${VENV_HOME_MNT:-/homedir}}"
+    export CENV_VSCS_MNT="${CENV_VSCS_MNT:-${VENV_HOME_MNT:-${HOME}/.vscode-server}}"
+
+    if [ "${CENV_HOME_DIR}" != "${HOME}" ]; then
+        mkdir -p "${CENV_HOME_DIR}"
+    fi
+
     export CENV_NAME="${CENV_NAME_ARG}"
     # Legacy support:
     export VENV_NAME="${CENV_NAME_ARG}"
@@ -458,6 +467,9 @@ else
         export SWMOD_MODPATH="${SWMOD_INST_BASE}"
 
         if [ "${CENV_RUNTIME}" = "apptainer" ]; then
+            if [ "${CENV_HOME_DIR}" != "${HOME}" ]; then
+                export APPTAINER_HOME="${CENV_HOME_DIR}"
+            fi
             export APPTAINERENV_PS1="[\u@\[\e[1m\]${CENV_NAME}\[\e[m\] cenv] \w > "
             export APPTAINER_SHELL="${APPTAINER_SHELL:-${SHELL}}"
             # Add user bin dir to path:
@@ -474,7 +486,7 @@ else
         if [ "${CENV_USER_MNT}" != "${CENV_USER_DIR}" ] ; then
             exec "${CENV_RUNTIME}" "${CMD}" ${EXTRA_OPTS} \
                 -B "${CENV_USER_DIR}:${CENV_USER_MNT}" \
-                -B "${HOME}:${CENV_HOME_MNT}" \
+                -B "${CENV_HOME_DIR}:${CENV_HOME_MNT}" \
                 -B "${CENV_USER_DIR}/.vscode-server:${CENV_VSCS_MNT}" \
                 "${FS_IMG}" "$@"
         else
@@ -504,11 +516,15 @@ else
         mkdir -p "${CENV_USER_DIR}"
         mkdir -p "${CENV_USER_DIR}/.vscode-server"
 
+        if [ "${CENV_HOME_DIR}" != "${HOME}" ]; then
+            export HOME="${CENV_HOME_DIR}"
+        fi
+
         export PS1="[\u@\[\e[1m\]${CENV_NAME}\[\e[m\] cenv] \w > "
 
         if [ "${CENV_USER_MNT}" != "${CENV_USER_DIR}" ] ; then
             exec shifter --image="${img_name}" \
-                --volume="${CENV_USER_DIR}:${CENV_USER_MNT};${HOME}:${CENV_HOME_MNT}" \
+                --volume="${CENV_USER_DIR}:${CENV_USER_MNT};${CENV_HOME_DIR}:${CENV_HOME_MNT}" \
                  ${EXTRA_OPTS} -- "$@"
         else
             exec shifter --image="${img_name}" \


### PR DESCRIPTION
This allows for creating more isolated containers, e.g. for safe agentic coding, via a `~/.cenv/some-contained-cenv/cenvrc` like

```shell
export CENV_HOME_DIR="${CENV_DIR}/homedir"
export CENV_USER_DIR="${CENV_BASE_DIR}/some-uncontained-cenv/user"

export APPTAINER_CONTAIN="1"

export CENV_APPTAINER_OPTS="
--bind /tmp:/tmp

--bind ${HOME}/some/dir:/homedir/some/dir
--bind ${HOME}/some/other/dir:/homedir/some/other/dir
"
```

This PR adds add support for Rust by pointing `$CARGO_HOME` and `$RUSTUP_HOME` to directories under `$CENV_USER_MNT` .

CC @gipert 